### PR TITLE
Add the path to the pdf.

### DIFF
--- a/prodigy_pdf/__init__.py
+++ b/prodigy_pdf/__init__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pypdfium2 as pdfium
 
 from prodigy import recipe, set_hashes, ControllerComponentsDict
-from prodigy.components.stream import Stream, get_stream
+from prodigy.components.stream import Stream
 from prodigy.util import msg
 
 def page_to_image(page: pdfium.PdfPage) -> str:

--- a/prodigy_pdf/__init__.py
+++ b/prodigy_pdf/__init__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pypdfium2 as pdfium
 
 from prodigy import recipe, set_hashes, ControllerComponentsDict
-from prodigy.components.stream import Stream
+from prodigy.components.stream import Stream, get_stream
 from prodigy.util import msg
 
 def page_to_image(page: pdfium.PdfPage) -> str:
@@ -30,6 +30,7 @@ def generate_pdf_pages(pdf_paths: List[Path]):
                 "meta": {
                     "page": page_number,
                     "pdf": pdf_path.parts[-1],
+                    "path": str(pdf_path)
                 }
             })
         pdf.close()


### PR DESCRIPTION
Make a quick patch here because it's needed for `ocr` to recover the entire pdf. 