### PR TITLE
pass metadata through in pdf.ocr.correct

### DIFF
--- a/prodigy_pdf/__init__.py
+++ b/prodigy_pdf/__init__.py
@@ -166,6 +166,12 @@ def pdf_ocr_correct(
                 if fold_dashes:
                     annot["text"] = fold_ocr_dashes(annot["text"])
                 annot["transcription"] = annot["text"]
+                
+                # passing through metadata, in order to connect OCR text & bounding boxes to the pdf images via path
+                # example usecase, finetuning a layoutLM on custom data
+                # see details here https://support.prodi.gy/t/pdf-ocr-image-annotation-metadata-feature-suggestion/7211
+                annot["meta"] = ex["meta"]
+                
                 text_input_fields = {
                     "field_rows": 12,
                     "field_label": "Transcript",


### PR DESCRIPTION
details can be found here: https://support.prodi.gy/t/pdf-ocr-image-annotation-metadata-feature-suggestion/7211

just a suggestion, in order to be able to link text transcription and bounding boxes to PDF data in order to train a layoutLM