### PR TITLE
add lang flag

### DIFF
--- a/prodigy_pdf/__init__.py
+++ b/prodigy_pdf/__init__.py
@@ -172,7 +172,7 @@ def _validate_ocr_example(stream):
     dataset=("Dataset to save answers to", "positional", None, str),
     source=("Source with PDF Annotations", "positional", None, str),
     labels=("Labels to consider", "option", "l", split_string),
-    lang=("Language for OCR", "option", "lang", str),
+    lang=("Language for OCR", "option", "la", str),
     scale=("Zoom scale. Increase above 3 to upscale the image for OCR.", "option", "s", int),
     remove_base64=("Remove base64-encoded image data", "flag", "R", bool),
     fold_dashes=("Removes dashes at the end of a textline and folds them with the next term.", "flag", "f", bool),

--- a/prodigy_pdf/__init__.py
+++ b/prodigy_pdf/__init__.py
@@ -172,6 +172,7 @@ def _validate_ocr_example(stream):
     dataset=("Dataset to save answers to", "positional", None, str),
     source=("Source with PDF Annotations", "positional", None, str),
     labels=("Labels to consider", "option", "l", split_string),
+    lang=("Language for OCR", "option", "lang", str),
     scale=("Zoom scale. Increase above 3 to upscale the image for OCR.", "option", "s", int),
     remove_base64=("Remove base64-encoded image data", "flag", "R", bool),
     fold_dashes=("Removes dashes at the end of a textline and folds them with the next term.", "flag", "f", bool),
@@ -182,6 +183,7 @@ def pdf_ocr_correct(
     dataset: str,
     source: str,
     labels: str,
+    lang: str = "eng",
     scale: int = 3,
     remove_base64: bool = False,
     fold_dashes: bool = False,
@@ -190,7 +192,7 @@ def pdf_ocr_correct(
     """Applies OCR to annotated segments and gives a textbox for corrections."""
     stream = get_stream(source)
 
-    def new_stream(stream):
+    def new_stream(stream, lang):
         for ex in stream:
             useful_spans = [
                 span for span in ex.get("spans", []) if span["label"] in labels
@@ -205,7 +207,7 @@ def pdf_ocr_correct(
                     pil_page, span=annot, scale=scale
                 )
                 annot["image"] = img_str
-                annot["text"] = pytesseract.image_to_string(cropped)
+                annot["text"] = pytesseract.image_to_string(cropped, lang=lang)
                 if fold_dashes:
                     annot["text"] = fold_ocr_dashes(annot["text"])
                 annot["transcription"] = annot["text"]
@@ -233,7 +235,7 @@ def pdf_ocr_correct(
 
     blocks = [{"view_id": "classification"}, {"view_id": "text_input"}]
     stream.apply(_validate_ocr_example)
-    stream.apply(new_stream)
+    stream.apply(new_stream, lang)
 
     return {
         "dataset": dataset,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.4.2
+version = 0.4.3
 description = Recipes for PDF annotation
 url = https://github.com/explosion/prodigy-pdf
 author = Explosion


### PR DESCRIPTION
It is now possible to pass `lang`parameter to `pytesseract` `image_to_string` method.
It supports `pytesseract` convention of mixing languages, for example `eng+fra`

To see the list if supported languages run
```
print(pytesseract.get_languages(config=''))
```
Currently supported list:

`['afr', 'amh', 'ara', 'asm', 'aze', 'aze_cyrl', 'bel', 'ben', 'bod', 'bos', 'bre', 'bul', 'cat', 'ceb', 'ces', 'chi_sim', 'chi_sim_vert', 'chi_tra', 'chi_tra_vert', 'chr', 'cos', 'cym', 'dan', 'deu', 'div', 'dzo', 'ell', 'eng', 'enm', 'epo', 'equ', 'est', 'eus', 'fao', 'fas', 'fil', 'fin', 'fra', 'frk', 'frm', 'fry', 'gla', 'gle', 'glg', 'grc', 'guj', 'hat', 'heb', 'hin', 'hrv', 'hun', 'hye', 'iku', 'ind', 'isl', 'ita', 'ita_old', 'jav', 'jpn', 'jpn_vert', 'kan', 'kat', 'kat_old', 'kaz', 'khm', 'kir', 'kmr', 'kor', 'kor_vert', 'lao', 'lat', 'lav', 'lit', 'ltz', 'mal', 'mar', 'mkd', 'mlt', 'mon', 'mri', 'msa', 'mya', 'nep', 'nld', 'nor', 'oci', 'ori', 'osd', 'pan', 'pol', 'por', 'pus', 'que', 'ron', 'rus', 'san', 'sin', 'slk', 'slv', 'snd', 'snum', 'spa', 'spa_old', 'sqi', 'srp', 'srp_latn', 'sun', 'swa', 'swe', 'syr', 'tam', 'tat', 'tel', 'tgk', 'tha', 'tir', 'ton', 'tur', 'uig', 'ukr', 'urd', 'uzb', 'uzb_cyrl', 'vie', 'yid', 'yor']`

